### PR TITLE
Use HTTPS URL for steno-dictionaries submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "didoesdigital"]
 	path = didoesdigital
-	url = git@github.com:didoesdigital/steno-dictionaries.git
+	url = https://github.com/didoesdigital/steno-dictionaries.git


### PR DESCRIPTION
This should allow contributors and Travis CI to clone the repo without authentication.