### PR TITLE
Add new Full Dictionary `typey-type-full.json`

### DIFF
--- a/dictionaries/dictionaryIndex.json
+++ b/dictionaries/dictionaryIndex.json
@@ -1,11 +1,21 @@
 [
   {
     "author": "Typey Type",
-    "title": "Dictionary",
+    "title": "Full Dictionary",
     "subtitle": "",
     "category": "Typey Type",
     "subcategory": "",
-    "tagline": "Typey Type’s slim dictionary follows the Plover dictionary with misstrokes removed from the top 10,000 words. It shows only 1 outline for each word.",
+    "tagline": "Typey Type’s full dictionary builds on the Plover dictionary with misstrokes removed from the top 10,000 words. Use this instead of Plover’s default main dictionary.",
+    "link": "/support#typey-type-dictionary",
+    "path": "/dictionaries/typey-type/typey-type-full.json"
+  },
+  {
+    "author": "Typey Type",
+    "title": "Slim Dictionary",
+    "subtitle": "",
+    "category": "Typey Type",
+    "subcategory": "",
+    "tagline": "Typey Type’s slim dictionary has only 1 outline for each word.",
     "link": "/support#typey-type-dictionary",
     "path": "/dictionaries/typey-type/typey-type.json"
   },

--- a/lessons/collections/tech/javascript-dom-events/javascript-dom-events.json
+++ b/lessons/collections/tech/javascript-dom-events/javascript-dom-events.json
@@ -90,7 +90,7 @@
 "KHAEUPBG": "change",
 "STORPBLG": "storage",
 "KHEG": "checking",
-"TKOUPBLGD": "downloading",
+"TKOUPBLD/-G": "downloading",
 "TPHO/A*UD": "noupdate",
 "OB/SHRAOET": "obsolete",
 "AUD/R*D": "updateready",

--- a/lessons/collections/tech/javascript-dom-events/lesson.txt
+++ b/lessons/collections/tech/javascript-dom-events/lesson.txt
@@ -95,7 +95,7 @@ JavaScript DOM events
 'change': KHAEUPBG
 'storage': STORPBLG
 'checking': KHEG
-'downloading': TKOUPBLGD
+'downloading': TKOUPBLD/-G
 'error': ROEUR
 'noupdate': TPHO/A*UD
 'obsolete': OB/SHRAOET

--- a/lessons/collections/tech/ruby/lesson.txt
+++ b/lessons/collections/tech/ruby/lesson.txt
@@ -1,6 +1,6 @@
 Ruby
 
-'ruby': RO*EUB
+'ruby': RAOU/PWEU
 ''2.2.0'': A*E/#T/P-P/#T/P-P/#O/AE
 '{}': WUZ/WUZ
 'source': S-RS

--- a/lessons/collections/tech/ruby/ruby.json
+++ b/lessons/collections/tech/ruby/ruby.json
@@ -1,5 +1,5 @@
 {
-"RO*EUB": "ruby",
+"RAOU/PWEU": "ruby",
 "A*E/#T/P-P/#T/P-P/#O/AE": "'2.2.0'",
 "WUZ/WUZ": "{}",
 "S-RS": "source",

--- a/lessons/stories/fables/the-bald-man-and-the-fly/lesson.txt
+++ b/lessons/stories/fables/the-bald-man-and-the-fly/lesson.txt
@@ -44,7 +44,7 @@ The Bald Man and the Fly
 'little': HREUL
 'enemy,': TPHAEPL/KW-BG
 'but': PWUT
-'—whack—': EPL/TKA*RB/WHABG/EPL/TKA*RB
+'—whack—': PH-RB/WHABG/EPL/TKA*RB
 'his': HEUS
 'palm': PAPL
 'came': KAEUPL

--- a/lessons/stories/fables/the-bald-man-and-the-fly/the-bald-man-and-the-fly.json
+++ b/lessons/stories/fables/the-bald-man-and-the-fly/the-bald-man-and-the-fly.json
@@ -37,7 +37,7 @@
 "HREUL": "little",
 "TPHAEPL/KW-BG": "enemy,",
 "PWUT": "but",
-"EPL/TKA*RB/WHABG/EPL/TKA*RB": "—whack—",
+"PH-RB/WHABG/EPL/TKA*RB": "—whack—",
 "PAPL": "palm",
 "HED": "head",
 "STPHED/STPH*FPLT": "instead;",


### PR DESCRIPTION
A few lessons have slight changes. The changes in tech lessons are now using entries from the main dictionaries instead of their recommended dict entries. The outline for `—whack—` is just an oddity that may get fixed later.

More info on https://github.com/didoesdigital/typey-type-cli/pull/14